### PR TITLE
Expand thesis draft with topology dynamics, archive formalism, and geometry visuals

### DIFF
--- a/thesis/draft.tex
+++ b/thesis/draft.tex
@@ -159,6 +159,124 @@ g_{\mu\nu} \to \Omega^2 g_{\mu\nu}
 so the late state can serve as an effective new initial condition.
 
 % =========================
+\section{Topology Persistence Dynamics}
+
+We formalize persistent curvature modes as slow variables in cosmological evolution.
+
+Let $\mathcal{T}$ denote the topological constraint field derived from primordial curvature.
+We model its evolution as
+
+\[
+\frac{\partial \mathcal{T}}{\partial t}
+=
+-\lambda \mathcal{D}[\mathcal{T}] + \eta
+\]
+
+where
+
+\begin{itemize}
+\item $\mathcal{D}$ represents dissipative baryonic backreaction
+\item $\lambda \ll 1$ expresses persistence
+\item $\eta$ encodes stochastic quantum fluctuations
+\end{itemize}
+
+In the persistence limit $\lambda \to 0$, topology behaves as an effective conserved quantity across cosmic epochs.
+
+% =========================
+\section{Horizon Archive Formalism}
+
+We treat the event horizon as a boundary encoding operator.
+
+Define a projection
+
+\[
+\Pi_H : \mathcal{W} \rightarrow \mathcal{H}
+\]
+
+mapping worldline data $\mathcal{W}$ to horizon microstates $\mathcal{H}$.
+
+Archive density scales with area:
+
+\[
+\rho_A = \frac{dS}{dA}
+\]
+
+Black hole mergers then act as information coarse-graining operations:
+
+\[
+\Pi_{H_{12}} = \mathcal{C}(\Pi_{H_1}, \Pi_{H_2})
+\]
+
+where $\mathcal{C}$ represents entropy-increasing compression.
+
+This reframes gravitational collapse as boundary accumulation rather than interior storage.
+
+% =========================
+\section{Cycle Phase Space and Renormalization}
+
+Cosmic cycles can be interpreted as scale transformations in configuration space.
+
+Let $\Lambda$ denote characteristic scale.
+We consider flow:
+
+\[
+\frac{d\mathcal{T}}{d\ln \Lambda} = \beta(\mathcal{T})
+\]
+
+where $\beta$ is a topology flow function.
+
+A fixed point
+
+\[
+\beta(\mathcal{T}_*) = 0
+\]
+
+represents a persistent cosmological skeleton inherited across cycles.
+
+This suggests cosmic recursion behaves analogously to renormalization group flow.
+
+% =========================
+\section{Standing Cosmic Web Geometry}
+
+\begin{center}
+\begin{tikzpicture}[scale=1.1]
+
+\foreach \x in {0,2,4}{
+\foreach \y in {0,2,4}{
+\fill (\x,\y) circle (2pt);
+}}
+
+\draw (0,0) -- (2,2) -- (4,4);
+\draw (4,0) -- (2,2) -- (0,4);
+\draw (0,2) -- (4,2);
+\draw (2,0) -- (2,4);
+
+\node at (2,-1) {Filament network as standing topology};
+
+\end{tikzpicture}
+\end{center}
+
+% =========================
+\section{Causal Archive Geometry}
+
+\begin{center}
+\begin{tikzpicture}[scale=1.2]
+
+\draw (-2,-2) -- (0,0) -- (2,-2);
+\draw (-2,2) -- (0,0) -- (2,2);
+
+\draw (0,0) circle (0.5);
+
+\node at (0,-2.4) {Past};
+\node at (0,2.4) {Future};
+\node at (0,0) {H};
+
+\end{tikzpicture}
+\end{center}
+
+The horizon $H$ acts as a causal boundary where worldlines terminate and archive encoding occurs.
+
+% =========================
 \section{Implications}
 
 \begin{itemize}


### PR DESCRIPTION
### Motivation
- Provide formal structure and mathematical spine to the speculative cosmology draft by introducing explicit dynamical, boundary, and renormalization-language elements. 
- Make the conceptual claims falsifiable by adding equations and definitions that can be connected to observables and simulations. 
- Improve exposition and pedagogy by adding simple TikZ visuals to illustrate the standing cosmic web and a Penrose-style causal archive. 

### Description
- Inserted a new `Topology Persistence Dynamics` section that defines a topological constraint field `\mathcal{T}` and proposes the evolution equation `\partial_t\mathcal{T} = -\lambda \mathcal{D}[\mathcal{T}] + \eta` with a persistence-limit interpretation. 
- Added `Horizon Archive Formalism` introducing the projection operator `\Pi_H : \mathcal{W} \rightarrow \mathcal{H}`, archive density `\rho_A = dS/dA`, and a coarse-graining merger operator `\mathcal{C}` for horizon merging. 
- Added `Cycle Phase Space and Renormalization` with RG-style flow `d\mathcal{T}/d\ln\Lambda = \beta(\mathcal{T})` and fixed-point language for cross-cycle inheritance. 
- Added two TikZ sections, `Standing Cosmic Web Geometry` and `Causal Archive Geometry`, providing simple illustrative diagrams and explanatory captions inside `thesis/draft.tex`. 

### Testing
- Attempted to compile the LaTeX source with `pdflatex`, but compilation could not be run because `pdflatex` is not available in this environment. 
- Verified the new sections were inserted into `thesis/draft.tex` by inspecting the file contents with a basic file preview command and confirming the expected equations and TikZ blocks appear. 
- No automated LaTeX build or unit tests were executed due to the missing `pdflatex` toolchain.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b6b697df883249063e7ba69461304)